### PR TITLE
Make the package work on precise again

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+libapache2-mod-ucam-webauth (2.0.2-1precise1) precise; urgency=medium
+
+  * Rebuild for precise
+  * Remove dependency on apache2-api-20120211 which doesn't exist on precise
+  * Work around nonexistence of apache2-maintscript-helper which also doesn't
+    exist on precise
+
+ -- Malcolm Scott <debianpkg@malc.org.uk>  Mon, 10 Aug 2015 16:37:16 +0100
+
 libapache2-mod-ucam-webauth (2.0.2-1vivid) vivid; urgency=medium
 
   * Rebuild for vivid

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/ucam-cl-dtg/libapache2-mod-ucam-webauth
 Vcs-Git: https://github.com/ucam-cl-dtg/libapache2-mod-ucam-webauth.git
 
 Package: libapache2-mod-ucam-webauth
-Depends: ${shlibs:Depends}, ${misc:Depends}, apache2, ucf (>=0.28), apache2-api-20120211
+Depends: ${shlibs:Depends}, ${misc:Depends}, apache2, ucf (>=0.28)
 Architecture: any
 Description: mod_ucam_webauth module for Apache 2
  mod_ucam_webauth is an Apache module implementing the University

--- a/debian/libapache2-mod-ucam-webauth.postinst
+++ b/debian/libapache2-mod-ucam-webauth.postinst
@@ -29,8 +29,6 @@ if [ -z "$serverdescr" ]
     serverdescr="Server description"
 fi
 
-. /usr/share/apache2/apache2-maintscript-helper
-
 
 case "$1" in
 configure|reconfigure)
@@ -63,13 +61,25 @@ EOF
 	rm -f "$newconf"
 
 	# Reload the module on upgrade if enabled
-	if [ -n "$2" ]; then
-		if apache2_has_module ucam_webauth; then
-			apache2_reload
+	if [ -e /usr/share/apache2/apache2-maintscript-helper ]
+	then
+		. /usr/share/apache2/apache2-maintscript-helper
+
+		if [ -n "$2" ]; then
+			if apache2_has_module ucam_webauth; then
+				apache2_reload
+			fi
+		else
+			# Enable the module
+			apache2_invoke enmod ucam_webauth
 		fi
-	else 
-		# Enable the module
-		apache2_invoke enmod ucam_webauth
+	else
+		# Old Apache2 package; approximately emulate apache2-maintscript-helper
+
+		if [ ! -n "$2" ]; then
+			/usr/sbin/a2enmod ucam_webauth || true
+		fi
+		/usr/sbin/apache2ctl restart || true
 	fi
 	;;
 

--- a/debian/libapache2-mod-ucam-webauth.prerm
+++ b/debian/libapache2-mod-ucam-webauth.prerm
@@ -16,23 +16,29 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-. /usr/share/apache2/apache2-maintscript-helper
-
 
 case "$1" in
 remove)
-        if apache2_has_module ucam_webauth ; then
-                apache2_invoke dismod ucam_webauth
-        fi
-        ;;
+	if [ -e /usr/share/apache2/apache2-maintscript-helper ]; then
+		. /usr/share/apache2/apache2-maintscript-helper
+
+		if apache2_has_module ucam_webauth ; then
+			apache2_invoke dismod ucam_webauth
+		fi
+	else
+		# Old Apache2 package
+		/usr/sbin/a2dismod ucam_webauth || true
+		/usr/sbin/apache2ctl restart || true
+	fi
+	;;
 
 upgrade|failed-upgrade|deconfigure)
-        ;;
+	;;
 
 *)
-        echo "prerm called with unknown argument \`$1'" >&2
-        exit 1
-        ;;
+	echo "prerm called with unknown argument \`$1'" >&2
+	exit 1
+	;;
 
 esac
 


### PR DESCRIPTION
Ubuntu Precise doesn't have an apache2-maintscript-helper.  Work around its absence.

(Not hugely tested, but it does work on at least one Precise system. :-) )
